### PR TITLE
treewide: Use kotlin design patterns

### DIFF
--- a/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/BaseActivity.kt
@@ -43,10 +43,11 @@ abstract class BaseActivity : ThemeChangeAwareActivity() {
             else -> null
         }
 
-        if (savedTunnelName != null)
+        savedTunnelName?.let {
             Application.tunnelManager.completableTunnels.thenAccept { tunnels ->
-                selectedTunnel = tunnels.get(savedTunnelName)
+                selectedTunnel = tunnels[it]
             }
+        }
 
         // The selected tunnel must be set before the superclass method recreates fragments.
         super.onCreate(savedInstanceState)
@@ -55,8 +56,9 @@ abstract class BaseActivity : ThemeChangeAwareActivity() {
     }
 
     override fun onSaveInstanceState(outState: Bundle?) {
-        if (this.selectedTunnel != null)
-            outState!!.putString(KEY_SELECTED_TUNNEL, this.selectedTunnel!!.getName())
+        selectedTunnel?.let {
+            outState?.putString(KEY_SELECTED_TUNNEL, it.getName())
+        }
         super.onSaveInstanceState(outState)
     }
 

--- a/app/src/main/java/com/wireguard/android/activity/MainActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
         // Do not show the home menu when the two-pane layout is at the detail view (see above).
         val backStackEntries = supportFragmentManager.backStackEntryCount
         val minBackStackEntries = if (isTwoPaneLayout) 2 else 1
-        actionBar!!.setDisplayHomeAsUpEnabled(backStackEntries >= minBackStackEntries)
+        actionBar?.setDisplayHomeAsUpEnabled(backStackEntries >= minBackStackEntries)
     }
 
     // We use onTouchListener here to avoid the UI click sound, hence

--- a/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
@@ -129,10 +129,10 @@ class SettingsActivity : ThemeChangeAwareActivity() {
         override fun onExcludedAppsSelected(excludedApps: List<String>) {
             ApplicationPreferences.exclusions = Attribute.iterableToString(excludedApps)
             Application.tunnelManager.completableTunnels
-                .thenAccept {
-                    for (tunnel: Tunnel in it) {
+                .thenAccept { tunnels ->
+                    tunnels.forEach { tunnel ->
                         val oldConfig = tunnel.getConfig()
-                        if (oldConfig != null) {
+                        oldConfig?.let {
                             oldConfig.`interface`.addExcludedApplications(Attribute.stringToList(ApplicationPreferences.exclusions))
                             tunnel.setConfig(oldConfig)
                             if (tunnel.getState() == Tunnel.State.UP)

--- a/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
@@ -14,6 +14,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.wireguard.android.Application
 import com.wireguard.android.R
 import com.wireguard.android.activity.MainActivity
+import com.wireguard.android.configStore.FileConfigStore.Companion.CONFIGURATION_FILE_SUFFIX
 import com.wireguard.android.model.Tunnel
 import com.wireguard.android.model.Tunnel.State
 import com.wireguard.android.model.Tunnel.Statistics
@@ -108,7 +109,7 @@ class WgQuickBackend(context: Context) : Backend {
     private fun setStateInternal(tunnel: Tunnel?, config: Config?, state: State?) {
         Objects.requireNonNull<Config>(config, "Trying to set state with a null config")
 
-        val tempFile = File(localTemporaryDir, tunnel?.getName() + ".conf")
+        val tempFile = File(localTemporaryDir, tunnel?.getName() + CONFIGURATION_FILE_SUFFIX)
         FileOutputStream(
             tempFile,
             false

--- a/app/src/main/java/com/wireguard/android/configStore/FileConfigStore.kt
+++ b/app/src/main/java/com/wireguard/android/configStore/FileConfigStore.kt
@@ -44,8 +44,8 @@ class FileConfigStore(private val context: Context) : ConfigStore {
 
     override fun enumerate(): Set<String> {
         return context.fileList()
-            .filter { it -> it.endsWith(".conf") }
-            .map { it -> it.substring(0, it.length - ".conf".length) }
+            .filter { it -> it.endsWith(CONFIGURATION_FILE_SUFFIX) }
+            .map { it -> it.substring(0, it.length - CONFIGURATION_FILE_SUFFIX.length) }
             .toSet()
     }
 
@@ -87,5 +87,6 @@ class FileConfigStore(private val context: Context) : ConfigStore {
 
     companion object {
         private val TAG = "WireGuard/" + FileConfigStore::class.java.simpleName
+        const val CONFIGURATION_FILE_SUFFIX = ".conf"
     }
 }

--- a/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/BaseFragment.kt
@@ -37,7 +37,7 @@ abstract class BaseFragment : Fragment(), OnSelectedTunnelChangedListener {
     private var pendingTunnelUp: Boolean? = null
 
     protected var selectedTunnel: Tunnel?
-        get() = if (activity != null) activity!!.selectedTunnel else null
+        get() = activity?.selectedTunnel
         set(tunnel) {
             activity?.selectedTunnel = tunnel
         }
@@ -63,8 +63,11 @@ abstract class BaseFragment : Fragment(), OnSelectedTunnelChangedListener {
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == REQUEST_CODE_VPN_PERMISSION) {
-            if (pendingTunnel != null && pendingTunnelUp != null)
-                setTunnelStateWithPermissionsResult(pendingTunnel!!, pendingTunnelUp!!)
+            pendingTunnel?.let { tunnel ->
+                pendingTunnelUp?.let { tunnelUp ->
+                    setTunnelStateWithPermissionsResult(tunnel, tunnelUp)
+                }
+            }
             pendingTunnel = null
             pendingTunnelUp = null
         }
@@ -84,10 +87,10 @@ abstract class BaseFragment : Fragment(), OnSelectedTunnelChangedListener {
         Application.backendAsync.thenAccept { backend ->
             if (backend is GoBackend) {
                 val intent = GoBackend.VpnService.prepare(view.context)
-                if (intent != null) {
+                intent?.let {
                     pendingTunnel = tunnel
                     pendingTunnelUp = checked
-                    startActivityForResult(intent, REQUEST_CODE_VPN_PERMISSION)
+                    startActivityForResult(it, REQUEST_CODE_VPN_PERMISSION)
                     return@thenAccept
                 }
             }

--- a/app/src/main/java/com/wireguard/android/fragment/ConfigNamingDialogFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/ConfigNamingDialogFragment.kt
@@ -46,9 +46,9 @@ class ConfigNamingDialogFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val activity = activity
 
-        imm = getActivity()!!.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
 
-        val alertDialogBuilder = AlertDialog.Builder(activity!!)
+        val alertDialogBuilder = AlertDialog.Builder(activity)
         alertDialogBuilder.setTitle(R.string.import_from_qrcode)
 
         binding = ConfigNamingDialogFragmentBinding.inflate(getActivity()!!.layoutInflater, null, false)
@@ -67,14 +67,14 @@ class ConfigNamingDialogFragment : DialogFragment() {
     }
 
     private fun createTunnelAndDismiss() {
-        if (binding != null) {
-            val name = binding!!.tunnelNameText.text.toString()
+        binding?.let {
+            val name = it.tunnelNameText.text.toString()
 
             Application.tunnelManager.create(name, config).whenComplete { tunnel, throwable ->
                 if (tunnel != null) {
                     dismiss()
                 } else {
-                    binding!!.tunnelNameTextLayout.error = throwable.message
+                    it.tunnelNameTextLayout.error = throwable.message
                 }
             }
         }

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelDetailFragment.kt
@@ -34,7 +34,7 @@ class TunnelDetailFragment : BaseFragment() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
-        inflater!!.inflate(R.menu.tunnel_detail, menu)
+        inflater?.inflate(R.menu.tunnel_detail, menu)
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelEditorFragment.kt
@@ -144,10 +144,12 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
     ): View? {
         super.onCreateView(inflater, container, savedInstanceState)
         binding = TunnelEditorFragmentBinding.inflate(inflater, container, false)
-        binding?.addOnPropertyChangedCallback(breakObjectOrientedLayeringHandler)
-        breakObjectOrientedLayeringHandlerReceivers.add(binding!!)
-        binding!!.executePendingBindings()
-        return binding!!.root
+        binding?.let {
+            it.addOnPropertyChangedCallback(breakObjectOrientedLayeringHandler)
+            breakObjectOrientedLayeringHandlerReceivers.add(it)
+            it.executePendingBindings()
+        }
+        return binding?.root
     }
 
     override fun onDestroyView() {
@@ -167,11 +169,11 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
         // Hide the keyboard; it rarely goes away on its own.
         val activity = activity ?: return
         val focusedView = activity.currentFocus
-        if (focusedView != null) {
+        focusedView?.let {
             val service = activity.getSystemService(Context.INPUT_METHOD_SERVICE)
             val inputManager = service as InputMethodManager
             inputManager.hideSoftInputFromWindow(
-                focusedView.windowToken,
+                it.windowToken,
                 InputMethodManager.HIDE_NOT_ALWAYS
             )
         }
@@ -193,7 +195,7 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
     }
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        when (item!!.itemId) {
+        when (item?.itemId) {
             R.id.menu_action_save -> {
                 val newConfig = Config()
                 try {
@@ -237,8 +239,8 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putParcelable(KEY_LOCAL_CONFIG, binding!!.config)
-        outState.putString(KEY_ORIGINAL_NAME, if (tunnel == null) null else tunnel!!.getName())
+        outState.putParcelable(KEY_LOCAL_CONFIG, binding?.config)
+        outState.putString(KEY_ORIGINAL_NAME, tunnel?.getName())
         super.onSaveInstanceState(outState)
     }
 
@@ -246,9 +248,10 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
         tunnel = newTunnel
         if (binding == null)
             return
-        binding!!.config = Config.Observable(null, null)
-        if (tunnel != null)
-            tunnel!!.configAsync.thenAccept { a -> onConfigLoaded(tunnel!!.getName(), a) }
+        binding?.config = Config.Observable(null, null)
+        tunnel?.let {
+            it.configAsync.thenAccept { a -> onConfigLoaded(it.getName(), a) }
+        }
     }
 
     private fun onTunnelCreated(newTunnel: Tunnel, throwable: Throwable?) {
@@ -263,8 +266,8 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
             val error = ExceptionLoggers.unwrapMessage(throwable)
             message = getString(R.string.tunnel_create_error, error)
             Timber.e(throwable)
-            if (binding != null) {
-                Snackbar.make(binding!!.mainContainer, message, Snackbar.LENGTH_LONG).show()
+            binding?.let {
+                Snackbar.make(it.mainContainer, message, Snackbar.LENGTH_LONG).show()
             }
         }
     }
@@ -285,8 +288,8 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
             val error = ExceptionLoggers.unwrapMessage(throwable)
             message = getString(R.string.tunnel_rename_error, error)
             Timber.e(throwable)
-            if (binding != null) {
-                Snackbar.make(binding!!.mainContainer, message, Snackbar.LENGTH_LONG).show()
+            binding?.let {
+                Snackbar.make(it.mainContainer, message, Snackbar.LENGTH_LONG).show()
             }
         }
     }
@@ -296,7 +299,7 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
             return
         }
 
-        binding!!.fragment = this
+        binding?.fragment = this
 
         if (savedInstanceState == null) {
             onSelectedTunnelChanged(null, selectedTunnel)
@@ -317,7 +320,7 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
     fun onRequestSetExcludedApplications(view: View) {
         val fragmentManager = fragmentManager
         if (fragmentManager != null && binding != null) {
-            val excludedApps = Attribute.stringToList(binding!!.config?.interfaceSection?.getExcludedApplications())
+            val excludedApps = Attribute.stringToList(binding?.config?.interfaceSection?.getExcludedApplications())
             val fragment = AppListDialogFragment.newInstance(excludedApps, target = this)
             fragment.show(fragmentManager, null)
         }
@@ -328,7 +331,7 @@ class TunnelEditorFragment : BaseFragment(), AppExclusionListener {
             binding,
             "Tried to set excluded apps while no view was loaded"
         )
-        binding!!.config?.interfaceSection?.setExcludedApplications(Attribute.iterableToString(excludedApps))
+        binding?.config?.interfaceSection?.setExcludedApplications(Attribute.iterableToString(excludedApps))
     }
 
     companion object {

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -243,7 +243,7 @@ class TunnelListFragment : BaseFragment() {
     private fun viewForTunnel(tunnel: Tunnel, tunnels: List<Tunnel>): MultiselectableRelativeLayout? {
         var view: MultiselectableRelativeLayout? = null
         binding?.let {
-            view = it.tunnelList.findViewHolderForAdapterPosition(tunnels.indexOf(tunnel))?.itemView as MultiselectableRelativeLayout
+            view = it.tunnelList.findViewHolderForAdapterPosition(tunnels.indexOf(tunnel))?.itemView as? MultiselectableRelativeLayout
         }
         return view
     }

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -234,21 +234,24 @@ class TunnelListFragment : BaseFragment() {
         intentIntegrator.initiateScan(listOf(IntentIntegrator.QR_CODE))
     }
 
-    private fun viewForTunnel(tunnel: Tunnel?, tunnels: List<*>): MultiselectableRelativeLayout? {
-        return if (binding != null && binding!!.tunnelList.findViewHolderForAdapterPosition(tunnels.indexOf(tunnel)) != null)
-            binding!!.tunnelList.findViewHolderForAdapterPosition(tunnels.indexOf(tunnel))!!.itemView as MultiselectableRelativeLayout
-        else
-            null
+    private fun viewForTunnel(tunnel: Tunnel, tunnels: List<Tunnel>): MultiselectableRelativeLayout? {
+        var view: MultiselectableRelativeLayout? = null
+        binding?.let {
+            view = it.tunnelList.findViewHolderForAdapterPosition(tunnels.indexOf(tunnel))?.itemView as MultiselectableRelativeLayout
+        }
+        return view
     }
 
     override fun onSelectedTunnelChanged(oldTunnel: Tunnel?, newTunnel: Tunnel?) {
         if (binding == null)
             return
         Application.tunnelManager.getTunnels().thenAccept { tunnels ->
-            if (newTunnel != null)
-                viewForTunnel(newTunnel, tunnels)!!.setSingleSelected(true)
-            if (oldTunnel != null)
-                viewForTunnel(oldTunnel, tunnels)!!.setSingleSelected(false)
+            newTunnel?.let {
+                viewForTunnel(it, tunnels)?.setSingleSelected(true)
+            }
+            oldTunnel?.let {
+                viewForTunnel(it, tunnels)?.setSingleSelected(false)
+            }
         }
     }
 

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -53,9 +53,9 @@ class TunnelListFragment : BaseFragment() {
             Config.from(configText)
 
             // Config text is valid, now create the tunnel…
-            val fragmentManager = fragmentManager
-            if (fragmentManager != null)
+            fragmentManager?.let {
                 ConfigNamingDialogFragment.newInstance(configText).show(fragmentManager, null)
+            }
         } catch (exception: Exception) {
             onTunnelImportFinished(emptyList(), listOf<Throwable>(exception))
         }
@@ -71,23 +71,25 @@ class TunnelListFragment : BaseFragment() {
         val throwables = ArrayList<Throwable>()
         Application.asyncWorker.supplyAsync {
             val columns = arrayOf(OpenableColumns.DISPLAY_NAME)
-            var name: String? = null
+            var name = ""
             @Suppress("Recycle")
-            contentResolver.query(uri, columns, null, null, null)!!.use { cursor ->
-                if (cursor.moveToFirst() && !cursor.isNull(0))
-                    name = cursor.getString(0)
+            contentResolver.query(uri, columns, null, null, null).use { cursor ->
+                cursor?.let {
+                    if (cursor.moveToFirst() && !cursor.isNull(0))
+                        name = cursor.getString(0)
+                }
             }
-            if (name == null)
+            if (name.isEmpty())
                 name = Uri.decode(uri.lastPathSegment)
-            var idx = name!!.lastIndexOf('/')
+            var idx = name.lastIndexOf('/')
             if (idx >= 0) {
-                if (idx >= name!!.length - 1)
-                    throw IllegalArgumentException("Illegal file name: " + name!!)
-                name = name!!.substring(idx + 1)
+                if (idx >= name.length - 1)
+                    throw IllegalArgumentException("Illegal file name: $name")
+                name = name.substring(idx + 1)
             }
-            val isZip = name!!.toLowerCase().endsWith(".zip")
-            if (name!!.toLowerCase().endsWith(".conf"))
-                name = name!!.substring(0, name!!.length - ".conf".length)
+            val isZip = name.toLowerCase().endsWith(".zip")
+            if (name.toLowerCase().endsWith(".conf"))
+                name = name.substring(0, name.length - ".conf".length)
             else if (!isZip)
                 throw IllegalArgumentException("File must be .conf or .zip")
 
@@ -100,14 +102,14 @@ class TunnelListFragment : BaseFragment() {
                         if (entry == null)
                             break
                         name = entry.name
-                        idx = name!!.lastIndexOf('/')
+                        idx = name.lastIndexOf('/')
                         if (idx >= 0) {
-                            if (idx >= name!!.length - 1)
+                            if (idx >= name.length - 1)
                                 continue
-                            name = name!!.substring(name!!.lastIndexOf('/') + 1)
+                            name = name.substring(name.lastIndexOf('/') + 1)
                         }
-                        if (name!!.toLowerCase().endsWith(".conf"))
-                            name = name!!.substring(0, name!!.length - ".conf".length)
+                        if (name.toLowerCase().endsWith(".conf"))
+                            name = name.substring(0, name.length - ".conf".length)
                         else
                             continue
                         var config: Config? = null
@@ -118,13 +120,13 @@ class TunnelListFragment : BaseFragment() {
                         }
 
                         if (config != null)
-                            futureTunnels.add(Application.tunnelManager.create(name!!, config).toCompletableFuture())
+                            futureTunnels.add(Application.tunnelManager.create(name, config).toCompletableFuture())
                     }
                 }
             } else {
                 futureTunnels.add(
                     Application.tunnelManager.create(
-                        name!!,
+                        name,
                         Config.from(contentResolver.openInputStream(uri))
                     ).toCompletableFuture()
                 )
@@ -152,8 +154,9 @@ class TunnelListFragment : BaseFragment() {
                             throwables.add(e)
                         }
 
-                        if (tunnel != null)
+                        tunnel?.let {
                             tunnels.add(tunnel)
+                        }
                     }
                     onTunnelImportFinished(tunnels, throwables)
                 }
@@ -203,11 +206,13 @@ class TunnelListFragment : BaseFragment() {
         }
 
         binding = TunnelListFragmentBinding.inflate(inflater, container, false)
-        binding!!.createFab.setOnClickListener { dialog.show() }
-        @Suppress("DEPRECATION")
-        binding!!.tunnelList.setOnScrollListener(FloatingActionButtonRecyclerViewScrollListener(binding!!.createFab))
-        binding!!.executePendingBindings()
-        return binding!!.root
+        binding?.let {
+            it.createFab.setOnClickListener { _ -> dialog.show() }
+            @Suppress("DEPRECATION")
+            it.tunnelList.setOnScrollListener(FloatingActionButtonRecyclerViewScrollListener(it.createFab))
+            it.executePendingBindings()
+        }
+        return binding?.root
     }
 
     override fun onDestroyView() {
@@ -264,8 +269,8 @@ class TunnelListFragment : BaseFragment() {
             message = resources.getQuantityString(R.plurals.delete_error, count, count, error)
             Timber.e(throwable)
         }
-        if (binding != null) {
-            Snackbar.make(binding!!.mainContainer, message, Snackbar.LENGTH_LONG).show()
+        binding?.let {
+            Snackbar.make(it.mainContainer, message, Snackbar.LENGTH_LONG).show()
         }
     }
 
@@ -296,18 +301,19 @@ class TunnelListFragment : BaseFragment() {
         Application.tunnelManager.completableTunnels.thenAccept { allTunnels ->
             for (tunnel in allTunnels) {
                 val oldConfig = tunnel.getConfig()
-                if (oldConfig != null) {
-                    oldConfig.getInterface()
+                oldConfig?.let {
+                    it.getInterface()
                         .addExcludedApplications(Attribute.stringToList(ApplicationPreferences.exclusions))
-                    tunnel.setConfig(oldConfig)
-                    if (tunnel.getState() === Tunnel.State.UP)
+                    tunnel.setConfig(it)
+                    if (tunnel.getState() == Tunnel.State.UP)
                         tunnel.setState(Tunnel.State.DOWN).whenComplete { _, _ -> tunnel.setState(Tunnel.State.UP) }
                 }
             }
         }
 
-        if (binding != null)
-            Snackbar.make(binding!!.mainContainer, message!!, Snackbar.LENGTH_LONG).show()
+        binding?.let {
+            Snackbar.make(it.mainContainer, message!!, Snackbar.LENGTH_LONG).show()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -319,10 +325,10 @@ class TunnelListFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        if (savedInstanceState != null) {
-            val checkedItems = savedInstanceState.getIntegerArrayList("CHECKED_ITEMS")
-            if (checkedItems != null) {
-                for (i in checkedItems)
+        savedInstanceState?.let { bundle ->
+            val checkedItems = bundle.getIntegerArrayList("CHECKED_ITEMS")
+            checkedItems?.let {
+                for (i in it)
                     actionModeListener.setItemChecked(i!!, true)
             }
         }
@@ -334,9 +340,9 @@ class TunnelListFragment : BaseFragment() {
         if (binding == null) {
             return
         }
-        binding!!.fragment = this
-        Application.tunnelManager.getTunnels().thenAccept { binding!!.tunnels = it }
-        binding!!.rowConfigurationHandler = object : ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler<TunnelListItemBinding, Tunnel> {
+        binding?.fragment = this
+        Application.tunnelManager.getTunnels().thenAccept { binding?.tunnels = it }
+        binding?.rowConfigurationHandler = object : ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler<TunnelListItemBinding, Tunnel> {
             override fun onConfigureRow(binding: TunnelListItemBinding, tunnel: Tunnel, position: Int) {
                 binding.fragment = this@TunnelListFragment
                 binding.root.setOnClickListener {
@@ -382,9 +388,10 @@ class TunnelListFragment : BaseFragment() {
                                 onTunnelDeletionFinished(count, throwable)
                             }
                     }
-                    if (binding != null)
-                        if (binding!!.createFab.isOrWillBeHidden)
-                            binding!!.createFab.show()
+                    binding?.let {
+                        if (it.createFab.isOrWillBeHidden)
+                            it.createFab.show()
+                    }
                     checkedItems.clear()
                     mode.finish()
                     return true
@@ -403,12 +410,13 @@ class TunnelListFragment : BaseFragment() {
 
         override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
             actionMode = mode
-            if (activity != null) {
-                resources = activity!!.resources
+            activity?.let {
+                resources = it.resources
             }
             mode.menuInflater.inflate(R.menu.tunnel_list_action_mode, menu)
-            if (binding != null)
-                binding!!.tunnelList.adapter!!.notifyDataSetChanged()
+            binding?.let {
+                it.tunnelList.adapter?.notifyDataSetChanged()
+            }
             return true
         }
 
@@ -416,8 +424,9 @@ class TunnelListFragment : BaseFragment() {
             actionMode = null
             resources = null
             checkedItems.clear()
-            if (binding != null)
-                binding!!.tunnelList.adapter!!.notifyDataSetChanged()
+            binding?.let {
+                it.tunnelList.adapter?.notifyDataSetChanged()
+            }
         }
 
         internal fun toggleItemChecked(position: Int) {
@@ -435,12 +444,12 @@ class TunnelListFragment : BaseFragment() {
                 checkedItems.remove(position)
             }
 
-            val adapter = if (binding == null) null else binding!!.tunnelList.adapter
+            val adapter = binding?.tunnelList?.adapter
 
-            if (actionMode == null && !checkedItems.isEmpty() && activity != null) {
+            if (actionMode == null && !checkedItems.isEmpty()) {
                 (activity as AppCompatActivity).startSupportActionMode(this)
-            } else if (actionMode != null && checkedItems.isEmpty()) {
-                actionMode!!.finish()
+            } else if (checkedItems.isEmpty()) {
+                actionMode?.finish()
             }
 
             adapter?.notifyItemChanged(position)

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -20,6 +20,7 @@ import com.google.zxing.integration.android.IntentIntegrator
 import com.wireguard.android.Application
 import com.wireguard.android.R
 import com.wireguard.android.activity.TunnelCreatorActivity
+import com.wireguard.android.configStore.FileConfigStore.Companion.CONFIGURATION_FILE_SUFFIX
 import com.wireguard.android.databinding.ObservableKeyedRecyclerViewAdapter
 import com.wireguard.android.databinding.TunnelListFragmentBinding
 import com.wireguard.android.databinding.TunnelListItemBinding
@@ -88,8 +89,8 @@ class TunnelListFragment : BaseFragment() {
                 name = name.substring(idx + 1)
             }
             val isZip = name.toLowerCase().endsWith(".zip")
-            if (name.toLowerCase().endsWith(".conf"))
-                name = name.substring(0, name.length - ".conf".length)
+            if (name.toLowerCase().endsWith(CONFIGURATION_FILE_SUFFIX))
+                name = name.substring(0, name.length - CONFIGURATION_FILE_SUFFIX.length)
             else if (!isZip)
                 throw IllegalArgumentException("File must be .conf or .zip")
 
@@ -108,8 +109,8 @@ class TunnelListFragment : BaseFragment() {
                                 continue
                             name = name.substring(name.lastIndexOf('/') + 1)
                         }
-                        if (name.toLowerCase().endsWith(".conf"))
-                            name = name.substring(0, name.length - ".conf".length)
+                        if (name.toLowerCase().endsWith(CONFIGURATION_FILE_SUFFIX))
+                            name = name.substring(0, name.length - CONFIGURATION_FILE_SUFFIX.length)
                         else
                             continue
                         var config: Config? = null

--- a/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
+++ b/app/src/main/java/com/wireguard/android/fragment/TunnelListFragment.kt
@@ -276,7 +276,7 @@ class TunnelListFragment : BaseFragment() {
     }
 
     private fun onTunnelImportFinished(tunnels: List<Tunnel>, throwables: Collection<Throwable>) {
-        var message: String? = null
+        var message = ""
 
         for (throwable in throwables) {
             val error = ExceptionLoggers.unwrapMessage(throwable)
@@ -313,7 +313,8 @@ class TunnelListFragment : BaseFragment() {
         }
 
         binding?.let {
-            Snackbar.make(it.mainContainer, message!!, Snackbar.LENGTH_LONG).show()
+            if (message.isNotEmpty())
+                Snackbar.make(it.mainContainer, message, Snackbar.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -86,10 +86,10 @@ class TunnelManager(private var configStore: ConfigStore) : BaseObservable() {
         lastUsedTunnel = tunnel
         notifyPropertyChanged(BR.lastUsedTunnel)
         Application.sharedPreferences.edit {
-            if (tunnel != null)
-                putString(KEY_LAST_USED_TUNNEL, tunnel.getName())
-            else
-                remove(KEY_LAST_USED_TUNNEL)
+            when {
+                tunnel != null -> putString(KEY_LAST_USED_TUNNEL, tunnel.getName())
+                else -> remove(KEY_LAST_USED_TUNNEL)
+            }
         }
     }
 

--- a/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -115,7 +115,7 @@ class TunnelManager(private var configStore: ConfigStore) : BaseObservable() {
             addToList(name, null, if (running.contains(name)) Tunnel.State.UP else Tunnel.State.DOWN)
         val lastUsedName = Application.sharedPreferences.getString(KEY_LAST_USED_TUNNEL, null)
         if (lastUsedName != null)
-            setLastUsedTunnel(tunnels.get(lastUsedName))
+            setLastUsedTunnel(tunnels[lastUsedName])
         var toComplete: Array<CompletableFuture<Void>>? = null
         synchronized(delayedLoadRestoreTunnels) {
             haveLoaded = true
@@ -123,11 +123,13 @@ class TunnelManager(private var configStore: ConfigStore) : BaseObservable() {
             delayedLoadRestoreTunnels.clear()
         }
         restoreState(true).whenComplete { v, t ->
-            for (f in toComplete!!) {
-                if (t == null)
-                    f.complete(v)
-                else
-                    f.completeExceptionally(t)
+            toComplete?.let {
+                for (f in it) {
+                    if (t == null)
+                        f.complete(v)
+                    else
+                        f.completeExceptionally(t)
+                }
             }
         }
 

--- a/app/src/main/java/com/wireguard/android/preference/ToolsInstallerPreference.kt
+++ b/app/src/main/java/com/wireguard/android/preference/ToolsInstallerPreference.kt
@@ -55,10 +55,10 @@ class ToolsInstallerPreference(context: Context, attrs: AttributeSet) : Preferen
             .whenComplete { result, throwable -> this.onInstallResult(result, throwable) }
     }
 
-    private fun onInstallResult(result: Int?, throwable: Throwable?) {
+    private fun onInstallResult(result: Int, throwable: Throwable?) {
         when {
             throwable != null -> setState(State.FAILURE)
-            result!! and ((ToolsInstaller.YES or ToolsInstaller.MAGISK)) == ToolsInstaller.YES or ToolsInstaller.MAGISK -> setState(
+            result and ((ToolsInstaller.YES or ToolsInstaller.MAGISK)) == ToolsInstaller.YES or ToolsInstaller.MAGISK -> setState(
                 State.SUCCESS_MAGISK
             )
             result and (ToolsInstaller.YES or ToolsInstaller.SYSTEM) == ToolsInstaller.YES or ToolsInstaller.SYSTEM -> setState(

--- a/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
+++ b/app/src/main/java/com/wireguard/android/util/SharedLibraryLoader.kt
@@ -42,7 +42,7 @@ object SharedLibraryLoader {
             var f: File? = null
             try {
                 f = File.createTempFile("lib", ".so", context.cacheDir)
-                Timber.tag(TAG).d("Extracting apk:/$libZipPath to ${f!!.absolutePath} and loading")
+                Timber.tag(TAG).d("Extracting apk:/$libZipPath to ${f?.absolutePath} and loading")
                 FileOutputStream(f).use { out ->
                     zipFile.getInputStream(zipEntry).use { inputStream ->
                         inputStream.copyTo(out)

--- a/app/src/main/java/com/wireguard/android/widget/ToggleSwitch.kt
+++ b/app/src/main/java/com/wireguard/android/widget/ToggleSwitch.kt
@@ -10,11 +10,9 @@ import android.os.Parcelable
 import android.util.AttributeSet
 import android.widget.Switch
 
-class ToggleSwitch(context: Context, attrs: AttributeSet?) : Switch(context, attrs) {
+class ToggleSwitch(context: Context, attrs: AttributeSet? = null) : Switch(context, attrs) {
     private var isRestoringState: Boolean = false
     private var listener: OnBeforeCheckedChangeListener? = null
-
-    constructor(context: Context) : this(context, null)
 
     override fun onRestoreInstanceState(state: Parcelable) {
         isRestoringState = true

--- a/app/src/main/java/com/wireguard/config/Interface.kt
+++ b/app/src/main/java/com/wireguard/config/Interface.kt
@@ -43,8 +43,9 @@ class Interface {
     }
 
     fun addExcludedApplications(applications: Array<String>?) {
-        if (applications != null && applications.isNotEmpty()) {
-            excludedApplications.addExclusive(applications)
+        applications?.let {
+            if (it.isNotEmpty())
+                excludedApplications.addExclusive(applications)
         }
     }
 
@@ -99,11 +100,11 @@ class Interface {
     }
 
     fun getPrivateKey(): String? {
-        return if (keypair == null) null else keypair!!.privateKey
+        return keypair?.privateKey
     }
 
     fun getPublicKey(): String? {
-        return if (keypair == null) null else keypair!!.publicKey
+        return keypair?.publicKey
     }
 
     fun parse(line: String) {
@@ -185,7 +186,7 @@ class Interface {
         if (mtu != 0)
             sb.append(Attribute.MTU.composeWith(mtu))
         if (keypair != null)
-            sb.append(Attribute.PRIVATE_KEY.composeWith(keypair!!.privateKey))
+            sb.append(Attribute.PRIVATE_KEY.composeWith(keypair?.privateKey))
         return sb.toString()
     }
 
@@ -211,14 +212,14 @@ class Interface {
                 loadData(parent)
         }
 
-        private constructor(`in`: Parcel) {
-            addresses = `in`.readString()
-            dnses = `in`.readString()
-            publicKey = `in`.readString()
-            privateKey = `in`.readString()
-            listenPort = `in`.readString()
-            mtu = `in`.readString()
-            excludedApplications = `in`.readString()
+        private constructor(input: Parcel) {
+            addresses = input.readString()
+            dnses = input.readString()
+            publicKey = input.readString()
+            privateKey = input.readString()
+            listenPort = input.readString()
+            mtu = input.readString()
+            excludedApplications = input.readString()
         }
 
         fun commitData(parent: Interface) {


### PR DESCRIPTION
Get rid of java patterns on nullability handling and similar
constructs in favour of a more Kotlin-y approach to doing
Kotlin. There should be no fundamental differenences in user
experience from the merge of this but the overall look of things
code-wise definitely improves.