### PR TITLE
tools: Switch back to bfd as the linker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ android:
     - build-tools-28.0.2
     - android-28
     - extra-android-m2repository
-    - ndk-bundle
   licenses:
     - ".+"
 
@@ -35,7 +34,6 @@ cache:
   directories:
     - "$HOME/.m2"
     - "$HOME/.gradle"
-    - "$ANDROID_HOME"
 
 before_install:
  - yes | sdkmanager "ndk-bundle"

--- a/app/tools/CMakeLists.txt
+++ b/app/tools/CMakeLists.txt
@@ -5,9 +5,6 @@
 cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 
-# Work around https://github.com/android-ndk/ndk/issues/602
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
-
 add_executable(libwg-quick.so wireguard/src/tools/wg-quick/android.c ndk-compat/compat.c)
 target_compile_options(libwg-quick.so PUBLIC -O3 -std=gnu11 -Wall -pedantic -Wno-missing-field-initializers -include ${CMAKE_CURRENT_SOURCE_DIR}/ndk-compat/compat.h -DWG_PACKAGE_NAME=\"${ANDROID_PACKAGE_NAME}\")
 
@@ -23,7 +20,6 @@ add_custom_target(libwg-go.so WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib
     ANDROID_SYSROOT=${ANDROID_SYSROOT}
     ANDROID_PACKAGE_NAME=${ANDROID_PACKAGE_NAME}
     CFLAGS=${CMAKE_C_FLAGS}\ -Wno-unused-command-line-argument
-    LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}\ -fuse-ld=gold
     DESTDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 # Hack to make it actually build as part of the default target

--- a/app/tools/CMakeLists.txt
+++ b/app/tools/CMakeLists.txt
@@ -20,6 +20,7 @@ add_custom_target(libwg-go.so WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib
     ANDROID_SYSROOT=${ANDROID_SYSROOT}
     ANDROID_PACKAGE_NAME=${ANDROID_PACKAGE_NAME}
     CFLAGS=${CMAKE_C_FLAGS}\ -Wno-unused-command-line-argument
+    LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}
     DESTDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
 )
 # Hack to make it actually build as part of the default target


### PR DESCRIPTION
The bug in question has been fixed for a bit now.

Reference:

https://github.com/android-ndk/ndk/issues/602#issuecomment-363224619
https://android.googlesource.com/toolchain/binutils/+/b6e5526f9ddd66b3c2a24ace4806873fc3b46920