### PR TITLE
Upstream sync

### DIFF
--- a/app/tools/libwg-go/src/api-android.go
+++ b/app/tools/libwg-go/src/api-android.go
@@ -60,7 +60,7 @@ func init() {
 }
 
 //export wgTurnOn
-func wgTurnOn(ifnameRef string, tun_fd int32, settings string) int32 {
+func wgTurnOn(ifnameRef string, tunFd int32, settings string) int32 {
 	interfaceName := string([]byte(ifnameRef))
 
 	logger := &Logger{
@@ -71,9 +71,9 @@ func wgTurnOn(ifnameRef string, tun_fd int32, settings string) int32 {
 
 	logger.Debug.Println("Debug log enabled")
 
-	tun, name, err := tun.CreateTUNFromFD(int(tun_fd))
+	tun, name, err := tun.CreateTUNFromFD(int(tunFd))
 	if err != nil {
-		unix.Close(int(tun_fd))
+		unix.Close(int(tunFd))
 		logger.Error.Println(err)
 		return -1
 	}
@@ -86,7 +86,7 @@ func wgTurnOn(ifnameRef string, tun_fd int32, settings string) int32 {
 	bufferedSettings := bufio.NewReadWriter(bufio.NewReader(strings.NewReader(settings)), bufio.NewWriter(ioutil.Discard))
 	setError := ipcSetOperation(device, bufferedSettings)
 	if setError != nil {
-		unix.Close(int(tun_fd))
+		unix.Close(int(tunFd))
 		logger.Error.Println(setError)
 		return -1
 	}
@@ -124,7 +124,7 @@ func wgTurnOn(ifnameRef string, tun_fd int32, settings string) int32 {
 		}
 	}
 	if i == math.MaxInt32 {
-		unix.Close(int(tun_fd))
+		unix.Close(int(tunFd))
 		return -1
 	}
 	tunnelHandles[i] = TunnelHandle{device: device, uapi: uapi}

--- a/app/tools/libwg-go/src/tun/api-android.go
+++ b/app/tools/libwg-go/src/tun/api-android.go
@@ -10,8 +10,8 @@ import (
 	"os"
 )
 
-func CreateTUNFromFD(tun_fd int) (TUNDevice, string, error) {
-	file := os.NewFile(uintptr(tun_fd), "/dev/tun")
+func CreateTUNFromFD(tunFd int) (TUNDevice, string, error) {
+	file := os.NewFile(uintptr(tunFd), "/dev/tun")
 	tun := &nativeTun{
 		tunFile: file,
 		fd:      file.Fd(),
@@ -20,7 +20,7 @@ func CreateTUNFromFD(tun_fd int) (TUNDevice, string, error) {
 		nopi:    true,
 	}
 	var err error
-	tun.fdCancel, err = rwcancel.NewRWCancel(tun_fd)
+	tun.fdCancel, err = rwcancel.NewRWCancel(tunFd)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
One useless formatting patch and a fix for wg-quick dying over an empty
AllowedIPs field which is actually valid according to the man pages [1] for
wg.8

[1]: https://git.zx2c4.com/WireGuard/commit/?id=01bbe9bbf11f695489e26ce23c6151e08754e9da