### PR TITLE
Refactor ToolsInstaller for Magisk v18 support

### DIFF
--- a/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
+++ b/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
@@ -27,6 +27,10 @@ class ToolsInstaller(context: Context) {
     private var areToolsAvailable: Boolean? = null
     private var installAsMagiskModule: Boolean? = null
 
+    init {
+        Timber.tag(TAG)
+    }
+
     @Throws(NoRootException::class)
     fun areInstalled(): Int {
         if (INSTALL_DIR == null)
@@ -61,15 +65,15 @@ class ToolsInstaller(context: Context) {
             val ret = symlink()
             areToolsAvailable = when (ret) {
                 OsConstants.EALREADY -> {
-                    Timber.tag(TAG).d("Tools were already symlinked into our private binary dir")
+                    Timber.d("Tools were already symlinked into our private binary dir")
                     true
                 }
                 OsConstants.EXIT_SUCCESS -> {
-                    Timber.tag(TAG).d("Tools are now symlinked into our private binary dir")
+                    Timber.d("Tools are now symlinked into our private binary dir")
                     true
                 }
                 else -> {
-                    Timber.tag(TAG).e("For some reason, wg and wg-quick are not available at all")
+                    Timber.e("For some reason, wg and wg-quick are not available at all")
                     false
                 }
             }

--- a/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
+++ b/app/src/main/java/com/wireguard/android/util/ToolsInstaller.kt
@@ -82,11 +82,13 @@ class ToolsInstaller(context: Context) {
 
     private fun willInstallAsMagiskModule(): Boolean {
         synchronized(lock) {
+            val magiskDirectory = getMagiskDirectory
+            Timber.tag("WTF").d("$magiskDirectory is being used.")
             if (installAsMagiskModule == null) {
                 installAsMagiskModule = try {
                     Application.rootShell.run(
                         null,
-                        "[ -d /sbin/.core/mirror -a -d /sbin/.core/img -a ! -f /cache/.disable_magisk ]"
+                        "[ -d $magiskDirectory/mirror -a -d $magiskDirectory/img -a ! -f /cache/.disable_magisk ]"
                     ) == OsConstants.EXIT_SUCCESS
                 } catch (ignored: Exception) {
                     false
@@ -121,24 +123,25 @@ class ToolsInstaller(context: Context) {
     @Throws(NoRootException::class)
     private fun installMagisk(): Int {
         val script = StringBuilder("set -ex; ")
+        val magiskDirectory = "$getMagiskDirectory/img/wireguard"
 
-        script.append("trap 'rm -rf /sbin/.core/img/wireguard' INT TERM EXIT; ")
+        script.append("trap 'rm -rf $magiskDirectory' INT TERM EXIT; ")
         script.append(
             String.format(
-                "rm -rf /sbin/.core/img/wireguard/; mkdir -p /sbin/.core/img/wireguard%s; ",
+                "rm -rf $magiskDirectory/; mkdir -p $magiskDirectory/%s; ",
                 INSTALL_DIR
             )
         )
         script.append(
             String.format(
-                "printf 'name=WireGuard Command Line Tools\nversion=%s\nversionCode=%s\nauthor=zx2c4\ndescription=Command line tools for WireGuard\nminMagisk=1500\n' > /sbin/.core/img/wireguard/module.prop; ",
+                "printf 'name=WireGuard Command Line Tools\nversion=%s\nversionCode=%s\nauthor=zx2c4\ndescription=Command line tools for WireGuard\nminMagisk=1500\n' > $magiskDirectory/module.prop; ",
                 BuildConfig.VERSION_NAME,
                 BuildConfig.VERSION_CODE
             )
         )
-        script.append("touch /sbin/.core/img/wireguard/auto_mount; ")
+        script.append("touch $magiskDirectory/auto_mount; ")
         for (names in EXECUTABLES) {
-            val destination = File("/sbin/.core/img/wireguard$INSTALL_DIR", names[1])
+            val destination = File("$magiskDirectory/$INSTALL_DIR", names[1])
             script.append(
                 String.format(
                     "cp '%s' '%s'; chmod 755 '%s'; restorecon '%s' || true; ",
@@ -213,6 +216,15 @@ class ToolsInstaller(context: Context) {
                         return dir
                 }
                 return null
+            }
+        private val getMagiskDirectory: String
+            get() {
+                val output = ArrayList<String>()
+                Application.rootShell.run(output, "su --version | cut -d ':' -f 1")
+                return when (output[0]) {
+                    "18.0" -> "/sbin/.magisk"
+                    else -> "/sbin/.core"
+                }
             }
     }
 }


### PR DESCRIPTION
Magisk v18 changed its working directory from `/sbin/.core/` to `/sbin/.magisk` with a reverse-compatible _for now_ symlink to the old directory which [has been removed](https://github.com/topjohnwu/Magisk/commit/c91f809ebaac87deaa24693510a99c7e263544df) for the next Magisk revision.

Let's get ahead of the game and simply choose to use the newer directory when available.

Fixes #93.