### PR TITLE
build: Enforce lint checks strictly

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,7 @@ android {
     }
     lintOptions {
         isAbortOnError = true
+        disable("UnusedResources")
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,7 +81,9 @@ android {
     externalNativeBuild.cmake {
         setPath(rootProject.file("$name/tools/CMakeLists.txt"))
     }
-    lintOptions.isAbortOnError = false
+    lintOptions {
+        isAbortOnError = true
+    }
 }
 
 dependencies {


### PR DESCRIPTION
- Make lint errors escalate build to failure
- Disable noisy unused resources check since they're
  all false positivies.